### PR TITLE
Add dtype to new_tokens tensor to avoid an error when decoding

### DIFF
--- a/onnxt5/models.py
+++ b/onnxt5/models.py
@@ -110,7 +110,7 @@ class GenerativeT5(torch.nn.Module):
 
         """
         with torch.no_grad():
-            new_tokens = torch.tensor(())
+            new_tokens = torch.tensor((), dtype=torch.long)
             new_logits = []
             generated = torch.tensor(self.tokenizer(prompt)['input_ids'])[:max_context_length - 1].unsqueeze(0)
             if self.cuda and not self.onnx:


### PR DESCRIPTION
Thanks for the repo!

I was having an error message come up when running the code after my initial install. 

Small code example:
```python
import os

import torch
from onnxt5 import GenerativeT5
from onnxt5.api import get_sess
from transformers import AutoTokenizer

model_dir = <path-to-tokenizer-and-onnx-files>
model_name = <name-of-model>

tokenizer = AutoTokenizer.from_pretrained(
    model_dir,
)

decoder_sess, encoder_sess = get_sess(
    os.path.join(model_dir, model_name)
)

model = GenerativeT5(
    encoder_sess,
    decoder_sess,
    tokenizer,
    onnx=True,
    cuda=torch.cuda.is_available(),
)

sentences = [
    "I has good grammar.",
    "I have bettr grammur."
]

corrected_sentences = [
    model(f"grammar: {sentence}",
          max_length=512,
          temperature=1,
          )[0]
    for sentence in sentences
]


```

The error
```
Traceback (most recent call last):
  File "/Users/jamiebrandon/Code/inferentia-test/onnx_example/compiled-t5-base-grammar-correction/code/inference.py", line 133, in <module>
    main()
  File "/Users/jamiebrandon/Code/inferentia-test/onnx_example/compiled-t5-base-grammar-correction/code/inference.py", line 125, in main
    prediction_output = predict_fn(input_data=input_tokens,
  File "/Users/jamiebrandon/Code/inferentia-test/onnx_example/compiled-t5-base-grammar-correction/code/inference.py", line 95, in predict_fn
    corrected_sentences = [model(f"grammar: {sentence}",
  File "/Users/jamiebrandon/Code/inferentia-test/onnx_example/compiled-t5-base-grammar-correction/code/inference.py", line 95, in <listcomp>
    corrected_sentences = [model(f"grammar: {sentence}",
  File "/Users/jamiebrandon/Code/inferentia-test/venv/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/jamiebrandon/Code/inferentia-test/onnx_example/compiled-t5-base-grammar-correction/onnxt5/onnxt5/models.py", line 154, in forward
    return self.tokenizer.decode(new_tokens), new_logits
  File "/Users/jamiebrandon/Code/inferentia-test/venv/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 3367, in decode
    return self._decode(
  File "/Users/jamiebrandon/Code/inferentia-test/venv/lib/python3.9/site-packages/transformers/tokenization_utils_fast.py", line 548, in _decode
    text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
TypeError: 'float' object cannot be interpreted as an integer
```

It seems the tensor for new tokens is of type float instead of long. Adding `dtype=torch.long` to the instantiation of the tensor resolved my issue, so I thought I'd share.
